### PR TITLE
fix: Update migration guide URL

### DIFF
--- a/src/main/groovy/githubChangelogGenerator.groovy
+++ b/src/main/groovy/githubChangelogGenerator.groovy
@@ -2,7 +2,7 @@ import groovy.json.JsonSlurper
 
 String header = '# Change Log\n\n'
 
-header += 'For upgrade instructions, please refer to https://docs.gravitee.io/apim_installguide_migration.html[APIM Migration Guide]\n\n'
+header += 'For upgrade instructions, please refer to https://docs.gravitee.io/apim/1.x/apim_installguide_migration.html[APIM Migration Guide]\n\n'
 header += '*Important:* If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.\n\n'
 
 String originChangelog = readFile('CHANGELOG.adoc').replace(header, '')


### PR DESCRIPTION
The migration guide url isn't up to date and does not link to an existing webpage (Fixes https://github.com/gravitee-io/issues/issues/3686)


